### PR TITLE
Prevent warning: Invalid argument supplied for foreach

### DIFF
--- a/wordmailmerge.php
+++ b/wordmailmerge.php
@@ -308,6 +308,8 @@ function wordmailmerge_civicrm_tokens(&$tokens){
 function wordmailmerge_civicrm_tokenValues(&$values, $cids, $job = null, $tokens = array(), $context = null){
 
   if (!empty($tokens['contact'])) {
+    if (is_null($cids) ) { $cids = array(); }
+    
     foreach($cids as $id){
       $params   = array('contact_id' => $id, 'version' => 3,);
       $contact  = civicrm_api( 'Contact' , 'get' , $params );


### PR DESCRIPTION
In some cases, CiviCRM triggers the `tokenValues` hook with the **$cids** set to null. With this patch, we prevent a *PHP Warning:  Invalid argument supplied for foreach()*.