### PR TITLE
fix count Parameter must be an array or an object error

### DIFF
--- a/CRM/Wordmailmerge/Form/WordMailMergeForm.php
+++ b/CRM/Wordmailmerge/Form/WordMailMergeForm.php
@@ -124,7 +124,7 @@ class CRM_Wordmailmerge_Form_WordMailMergeForm extends CRM_Contact_Form_Task {
     while ($tableCount->fetch()) {
       $noofRows = $tableCount->id;
     }
-    $rowCount = count($noofRows);
+    $rowCount = count((array)$noofRows);
     if( $rowCount == 0){
       $this->add('select', 'message_template', ts('Message Template'), array('' => '- select -'), TRUE);
       CRM_Core_Session::setStatus(ts("No attachement in the template."));

--- a/CRM/Wordmailmerge/Form/WordMailMergeForm.php
+++ b/CRM/Wordmailmerge/Form/WordMailMergeForm.php
@@ -122,7 +122,7 @@ class CRM_Wordmailmerge_Form_WordMailMergeForm extends CRM_Contact_Form_Task {
     $tableCount = CRM_Core_DAO::executeQuery($mysql);
     $noofRows = array();
     while ($tableCount->fetch()) {
-      $noofRows = $tableCount->id;
+      $noofRows[] = $tableCount->id;
     }
     $rowCount = count((array)$noofRows);
     if( $rowCount == 0){


### PR DESCRIPTION
Fixed  `Warning: count(): Parameter must be an array or an object that implements Countable in CRM_Wordmailmerge_Form_WordMailMergeForm->buildQuickForm()
`